### PR TITLE
add gulpfile to make workflow easier to develop and test

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,22 @@
+{
+    "brace_style": "collapse",
+    "break_chained_methods": false,
+    "e4x": false,
+    "eval_code": false,
+    "indent_char": " ",
+    "indent_level": 0,
+    "indent_size": 2,
+    "indent_with_tabs": false,
+    "jslint_happy": true,
+    "keep_array_indentation": false,
+    "keep_function_indentation": false,
+    "max_preserve_newlines": 3,
+    "preserve_newlines": true,
+    "space_before_conditional": true,
+    "space_in_paren": false,
+    "unescape_strings": false,
+    "wrap_line_length": 80,
+    "wrap-attributes-indent-size": 2,
+    "wrap-attributes": "force",
+    "preserve-newlines": true
+  }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,17 @@
+'use strict';
+var gulp = require('gulp');
+var slushTask = require('./slushfile');
+var prettify = require('gulp-jsbeautifier');
+
+gulp.task('beautify', function () {
+  gulp.src('*.js', {
+      base: '.'
+    })
+    .pipe(prettify({
+      config: '.jsbeautifyrc',
+      mode: 'VERIFY_AND_WRITE'
+    }))
+    .pipe(gulp.dest('.'));
+});
+
+gulp.task('serve', slushTask);

--- a/package.json
+++ b/package.json
@@ -1,43 +1,49 @@
 {
-    "name": "slush-ng-next-component",
-    "description": "slush generator for ng-next style Angular component",
-    "version": "0.1.0",
-    "homepage": "https://github.com/wzaghal/slush-ng-next-component",
-    "author": {
-        "name": "wzaghal",
-        "email": "wisamzaghal@gmail.com"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/wzaghal/slush-ng-next-component.git"
-    },
-    "bugs": {
-        "url": "https://github.com/wzaghal/slush-ng-next-component/issues"
-    },
-    "licenses": [{
-        "type": "MIT",
-        "url": "https://github.com/wzaghal/slush-ng-next-component/blob/master/LICENSE"
-    }],
-    "main": "slushfile.js",
-    "engines": {
-        "node": ">= 0.10.26",
-        "npm": ">=1.4.3"
-    },
-    "scripts": {
-        "test": "echo \"No tests\""
-    },
-    "dependencies": {
-        "slush": ">=1.0.0",
-        "gulp": "^3.6.2",
-        "gulp-template": "^0.1.1",
-        "gulp-install": "^0.1.4",
-        "gulp-conflict": "^0.1.1",
-        "gulp-rename": "^1.2.0",
-        "underscore.string": "^2.3.3",
-        "inquirer": "^0.8.0",
-        "iniparser": "^1.0.5"
-    },
-    "keywords": [
-        "slushgenerator"
-    ]
+  "name": "slush-ng-next-component",
+  "description": "slush generator for ng-next style Angular component",
+  "version": "0.1.0",
+  "homepage": "https://github.com/wzaghal/slush-ng-next-component",
+  "author": {
+    "name": "wzaghal",
+    "email": "wisamzaghal@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/wzaghal/slush-ng-next-component.git"
+  },
+  "bugs": {
+    "url": "https://github.com/wzaghal/slush-ng-next-component/issues"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/wzaghal/slush-ng-next-component/blob/master/LICENSE"
+    }
+  ],
+  "main": "slushfile.js",
+  "engines": {
+    "node": ">= 0.10.26",
+    "npm": ">=1.4.3"
+  },
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "bluebird": "^2.9.34",
+    "gulp": "^3.6.2",
+    "gulp-conflict": "^0.1.1",
+    "gulp-install": "^0.1.4",
+    "gulp-rename": "^1.2.0",
+    "gulp-template": "^0.1.1",
+    "iniparser": "^1.0.5",
+    "inquirer": "^0.8.0",
+    "slush": ">=1.0.0",
+    "underscore.string": "^2.3.3"
+  },
+  "keywords": [
+    "slushgenerator"
+  ],
+  "devDependencies": {
+    "gulp-jsbeautifier": "^1.0.1"
+  }
 }

--- a/slushfile.js
+++ b/slushfile.js
@@ -8,44 +8,55 @@ var rename = require('gulp-rename');
 var _ = require('underscore.string');
 var inquirer = require('inquirer');
 var path = require('path');
+var Promise = require('bluebird');
 
-gulp.task('default', function (done) {
-  var prompts = [
-    {
+gulp.task('default', run);
+module.exports = run;
+
+function run(done) {
+  prompt()
+    .then(generate(done))
+
+};
+
+function validateInput(input) {
+  var errorMessage = 'Input contains invalid characters! Please try again';
+  if (input.split(' ').length > 1) {
+    return errorMessage;
+  }
+
+  return true;
+
+};
+
+function replaceWithAnswers(component) {
+  return function (file) {
+    if (file.basename === 'component') {
+      file.basename = file.basename.replace(/component/, component.name);
+    }
+  }
+
+}
+
+function prompt() {
+  return new Promise(function (resolve) {
+    var prompts = [{
       name: 'name',
       message: 'What is the name of your component?',
       validate: validateInput
-    }
-  ];
-
-  inquirer.prompt(prompts, function (component) {
-
-    gulp.src(__dirname + '/templates/**')
-    .pipe(template(component))
-    .pipe(rename(replaceWithAnswers(component)))
-    .pipe(conflict('./'))
-    .pipe(gulp.dest('./'))
-    .pipe(install())
-    .on('end', done);
+    }];
+    return inquirer.prompt(prompts, resolve);
   });
+}
 
-  function validateInput(input) {
-    var errorMessage = 'Input contains invalid characters! Please try again';
-    if (input.split(' ').length > 1) {
-      return errorMessage;
-    }
-
-    return true;
-
-  };
-
-  function replaceWithAnswers(component) {
-    return function(file){
-      if (file.basename === 'component'){
-        file.basename = file.basename.replace(/component/,component.name);
-      }
-    }
-
+function generate(done) {
+  return function (component) {
+    gulp.src(__dirname + '/templates/**')
+      .pipe(template(component))
+      .pipe(rename(replaceWithAnswers(component)))
+      .pipe(conflict('./'))
+      .pipe(gulp.dest('./'))
+      .pipe(install())
+      .on('end', done);
   }
-
-});
+};


### PR DESCRIPTION
The `slushfile.js` is just a glorified gulpfile. So in order to run and test that it's working correctly, you have to rename the file to gulpfile.js and execute the gulp task.

So I created a gulpfile.js which imports the function so that this can be avoided. Also this meant breaking things down into functions, which will make it easier to write tests. I also added a beautify gulp task.
